### PR TITLE
Fix rss links and only render redirect code on posts and pages

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -1,4 +1,12 @@
 {{#post}}
+{{#is "post, page"}}
+<script tpye="text/javascript">
+    if ((window.location.href.match("#") == null) && (window.location.pathname != "/")) {
+        var loc = "/#" + window.location.pathname.substr(1);
+        window.location = loc;
+    }
+</script>
+{{/is}}
 
 <main class="main_pixel post" role="main">
 


### PR DESCRIPTION
The rss links normally won't work without this.  This redirects posts (and pages) to the proper page starting with "#", so that the whole theme loads.  This prevents the need for any fancy http-mod-redirect on the server end.